### PR TITLE
test: pin Matchstick binary version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "create-local": "graph create --node http://localhost:8020/ nifty-league-sepolia",
     "remove-local": "graph remove --node http://localhost:8020/ nifty-league-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 nifty-league-sepolia",
-    "test": "graph test",
+    "test": "graph test --version 0.6.0",
     "test:coverage": "node scripts/check-coverage.mjs"
   },
   "devDependencies": {

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 
 const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
-const child = spawn(command, ['exec', 'graph', 'test', '--', '-c'], {
+const child = spawn(command, ['exec', 'graph', 'test', '--version', '0.6.0', '--coverage'], {
   stdio: ['inherit', 'pipe', 'pipe'],
 });
 


### PR DESCRIPTION
## Summary
- pin the Matchstick runtime to 0.6.0 for normal and coverage tests
- avoid flaky runtime discovery of the latest GitHub release

## Validation
- 4 Matchstick tests pass
- handler coverage remains 28.6% (minimum 25%)
- production dependency audit reports no known vulnerabilities